### PR TITLE
update rbind.pages to rbind_pages.

### DIFF
--- a/R/jobSearch.R
+++ b/R/jobSearch.R
@@ -109,7 +109,7 @@ jobSearch <- function(publisher, query, country = "us", location="", radius=25,
                                                      as = "text", encoding = "UTF-8")))
     })
     
-    jsonlite::rbind.pages(jobs_lists)
+    jsonlite::rbind_pages(jobs_lists)
   }
   
 }


### PR DESCRIPTION
Fix the following error which results from calling the `jobSearch()` function.
The error is a result from updates to the `jsonlite::rbind.pages` dependency, which has been deprecated and change to `rbind_pages`. 

```
Warning message:
'jsonlite::rbind.pages' is deprecated.
Use 'rbind_pages' instead.
See help("Deprecated")
```